### PR TITLE
Fix "self" error in SSR with beautiful fix!

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
     mode: 'development',
     devtool: 'source-map',
     output: {
-        globalObject: `typeof (self !== 'undefined') ? self : this`,
+        globalObject: `(function(){ try{ return typeof self !== 'undefined'}catch(err){return false}})()`,
         path: path.resolve(__dirname, 'dist'),
         filename: 'aem-spa-component-mapping.js',
         library: 'cqSpaComponentMapping',


### PR DESCRIPTION
This fixes the weird "self not defined" error in server side rendering mode which kills SSR (due to typescript conversion)

This should be handled better by webpack 5: https://github.com/webpack/webpack/pull/8625

But webpack 5 is in beta and upgrading means breaking config changes.